### PR TITLE
Code cleanup

### DIFF
--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -52,7 +52,7 @@ impl IoCondition for Comparison {
                 } else {
                     return Err(Error::new(
                         InvalidInput,
-                        format!("Bits can only compared with other bits"),
+                        "Bits can only compared with other bits",
                     ));
                 }
             }
@@ -69,7 +69,7 @@ impl IoCondition for Comparison {
                 } else {
                     return Err(Error::new(
                         InvalidInput,
-                        format!("Decimal values can only compared with other decimals"),
+                        "Decimal values can only compared with other decimals",
                     ));
                 }
             }
@@ -86,7 +86,7 @@ impl IoCondition for Comparison {
                 } else {
                     return Err(Error::new(
                         InvalidInput,
-                        format!("Integer values can only compared with other integers"),
+                        "Integer values can only compared with other integers",
                     ));
                 }
             }
@@ -109,7 +109,7 @@ impl IoCondition for Comparison {
                 } else {
                     return Err(Error::new(
                         InvalidInput,
-                        format!("Text values can only compared with other text"),
+                        "Text values can only compared with other text",
                     ));
                 }
             }
@@ -132,7 +132,7 @@ impl IoCondition for Comparison {
                 } else {
                     return Err(Error::new(
                         InvalidInput,
-                        format!("Binary data can only compared with other binary data"),
+                        "Binary data can only compared with other binary data",
                     ));
                 }
             }

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -83,7 +83,7 @@ impl<'a> From<&'a str> for Output {
     }
 }
 
-/// A loop contiuously triggers a controller again and again.
+/// A loop continuously triggers a controller again and again.
 #[derive(Debug, Clone)]
 pub struct Loop {
     /// The unique ID of the rule
@@ -96,7 +96,7 @@ pub struct Loop {
     pub controller: ControllerConfig,
 }
 
-/// A fixed interval
+/// A periodic interval with a fixed duration
 #[derive(Debug, Clone)]
 pub struct Interval {
     /// The unique ID of the interval

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod pid;
 /// Bang-bang controller
 pub mod bang_bang;
 
-/// A generic statefull controller
+/// A generic stateful controller
 pub trait Controller<Input, Output> {
     /// Calculate the next state.
     fn next(&mut self, input: Input) -> Output;
@@ -29,7 +29,7 @@ pub trait PureController<Input, Output> {
     fn next(&self, input: Input) -> Output;
 }
 
-/// A generic statefull controller with time steps
+/// A generic stateful controller with time steps
 pub trait TimeStepController<Input, Output> {
     /// Calculate the next state.
     fn next(&mut self, input: Input, delta_t: &Duration) -> Output;

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -59,7 +59,7 @@ pub struct PidState {
     pub p: f64,
     /// Integral portion (error sum)
     pub i: f64,
-    /// Derative portion
+    /// Derivative portion
     pub d: f64,
 }
 
@@ -100,7 +100,7 @@ pub struct PidConfig {
     pub k_p: f64,
     /// Integral coefficient
     pub k_i: f64, // Ki = Kp / Ti
-    /// Derivativ coefficient
+    /// Derivative coefficient
     pub k_d: f64, // Kd = Kp * Td
     /// The default setpoint
     pub default_target: f64,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -129,7 +129,7 @@ impl<'a> PureController<(&'a SyncSystemState, &'a str, &'a Duration), Result<Syn
                         if let Value::Decimal(v) = s {
                             match c {
                                 ControllerState::Pid(pid) => {
-                                    let mut pid = pid.clone();
+                                    let mut pid = *pid;
                                     pid.target = *v;
                                     state
                                         .runtime
@@ -137,7 +137,7 @@ impl<'a> PureController<(&'a SyncSystemState, &'a str, &'a Duration), Result<Syn
                                         .insert(id.clone(), ControllerState::Pid(pid));
                                 }
                                 ControllerState::BangBang(bb) => {
-                                    let mut bb = bb.clone();
+                                    let mut bb = *bb;
                                     bb.threshold = *v;
                                     state
                                         .runtime

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -88,9 +88,9 @@ impl<'a>
         state.rules = self.rules_state(&io)?;
         for (r_id, _) in state.rules.iter().filter(|(_, active)| **active) {
             if let Some(r) = self.rules.iter().find(|r| r.id == *r_id) {
-                for a_id in r.actions.iter() {
+                for a_id in &r.actions {
                     if let Some(a) = self.actions.iter().find(|a| a.id == *a_id) {
-                        for (k, src) in a.outputs.iter() {
+                        for (k, src) in &a.outputs {
                             match src {
                                 Source::In(id) => {
                                     if let Some(v) = orig_io.inputs.get(id) {
@@ -123,7 +123,7 @@ impl<'a> PureController<(&'a SyncSystemState, &'a str, &'a Duration), Result<Syn
         let mut state = orig_state.clone();
 
         if let Some(loops) = self.loops.get(input.1) {
-            for (id, s) in input.0.setpoints.iter() {
+            for (id, s) in &input.0.setpoints {
                 if loops.iter().any(|l| l.id == *id) {
                     if let Some(c) = input.0.runtime.controllers.get(id) {
                         if let Value::Decimal(v) = s {
@@ -159,9 +159,9 @@ impl<'a> PureController<(&'a SyncSystemState, &'a str, &'a Duration), Result<Syn
         state.io = io;
         for (r_id, _) in state.runtime.rules.iter().filter(|(_, active)| **active) {
             if let Some(r) = self.rules.iter().find(|r| r.id == *r_id) {
-                for a_id in r.actions.iter() {
+                for a_id in &r.actions {
                     if let Some(a) = self.actions.iter().find(|a| a.id == *a_id) {
-                        for (k, src) in a.setpoints.iter() {
+                        for (k, src) in &a.setpoints {
                             match src {
                                 Source::In(id) => {
                                     if let Some(v) = orig_state.io.inputs.get(id) {
@@ -190,7 +190,7 @@ impl SyncRuntime {
     /// Check for active [Rule]s.
     fn rules_state(&self, io: &IoState) -> Result<HashMap<String, bool>> {
         let mut rules_state = HashMap::new();
-        for r in self.rules.iter() {
+        for r in &self.rules {
             let state = r.condition.eval(io)?;
             rules_state.insert(r.id.clone(), state);
         }


### PR DESCRIPTION
The result of various flyby edits while reading the code, no major changes:
* Changes proposed by clippy, some are still left
* Minor optimizations when parsing comparison expressions
* Improved type-safety for durations
* Improved numeric robustness of PID calculation. Please check if you agree! Maybe we should also add tests for very small deltas (both time and value -> f64::EPSILON)?